### PR TITLE
update dependencies to be compatible with 3.10.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>15</version>
+        <version>20.0</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -35,16 +35,33 @@
     <name>Gravitee.io APIM - Resource - Auth Provider - HTTP</name>
 
     <properties>
+        <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.26.0</gravitee-gateway-api.version>
-        <gravitee-node-api.version>1.15.1</gravitee-node-api.version>
-        <gravitee-resource-auth-provider.version>1.1.0</gravitee-resource-auth-provider.version>
+        <gravitee-gateway-api.version>1.27.3</gravitee-gateway-api.version>
+        <gravitee-node-api.version>1.16.5</gravitee-node-api.version>
+        <gravitee-resource-auth-provider.version>1.2.0</gravitee-resource-auth-provider.version>
+
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+
+        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Gravitee dependencies -->
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee.io API-->
@@ -79,7 +96,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>${vertx.version}</version>
             <scope>provided</scope>
         </dependency>
      </dependencies>


### PR DESCRIPTION
**Description**

- update dependencies to be compatible with 3.10.x
- Adapt code to use Vert.X 4
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-SNAPSHOT.apim-3-10-compatibility`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-http/1.2.0-SNAPSHOT.apim-3-10-compatibility/gravitee-resource-auth-provider-http-1.2.0-SNAPSHOT.apim-3-10-compatibility.zip)
  <!-- Version placeholder end -->
