### PR TITLE
fix: catch ExpressionEvaluationException when using EL

### DIFF
--- a/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
@@ -142,7 +142,7 @@ public class HttpAuthenticationProviderResource
                             if (extValue != null) {
                                 httpClientRequest.putHeader(header.getName(), extValue);
                             }
-                        } catch (Exception ex) {
+                        } catch (ExpressionEvaluationException ex) {
                             // Do nothing
                         }
                     });
@@ -151,8 +151,12 @@ public class HttpAuthenticationProviderResource
             String body = null;
 
             if (configuration().getBody() != null && !configuration().getBody().isEmpty()) {
-                // Body can be dynamically resolved using el expression.
-                body = context.getTemplateEngine().getValue(configuration().getBody(), String.class);
+                try {
+                    // Body can be dynamically resolved using el expression.
+                    body = context.getTemplateEngine().getValue(configuration().getBody(), String.class);
+                } catch (ExpressionEvaluationException ex) {
+                    // Do nothing
+                }
             }
 
             // Check the resolved body before trying to send it.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4426
**Description**

catch ExpressionEvaluationException when using EL

_P.S : prefers explicit EL catching to overly permissive catching_

To test ex : 
Create  Keyless API with "HTTP Authentication Provider resource" configured to echo api. Use this resource with "Bas Authentification".
On resource play with body , header & condition to add good or bad EL 
 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
