### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.authprovider.http.HttpAuthenticationProviderResource
 type=resource
 icon=http.svg
+category=Authentication

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,13 +1,23 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:resource:authprovider:http:HttpIdentityProviderConfiguration",
-  "properties" : {
-    "method" : {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "method": {
       "title": "HTTP Method",
       "description": "HTTP method to invoke the endpoint.",
-      "type" : "string",
+      "type": "string",
       "default": "POST",
-      "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "CONNECT", "OPTIONS", "TRACE" ]
+      "enum": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "CONNECT",
+        "OPTIONS",
+        "TRACE"
+      ]
     },
     "useSystemProxy": {
       "title": "Use system proxy",
@@ -17,23 +27,23 @@
     "url": {
       "title": "URL",
       "description": "Server url",
-      "type" : "string"
+      "type": "string"
     },
-    "headers" : {
-      "type" : "array",
+    "headers": {
+      "type": "array",
       "title": "Request Headers",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:io:gravitee:resource:authprovider:http:configuration:HttpHeader",
+      "description": "Header value support EL",
+      "items": {
+        "type": "object",
         "title": "Header",
-        "properties" : {
-          "name" : {
+        "properties": {
+          "name": {
             "title": "Name",
-            "type" : "string"
+            "type": "string"
           },
-          "value" : {
+          "value": {
             "title": "Value (support EL)",
-            "type" : "string",
+            "type": "string",
             "x-schema-form": {
               "expression-language": true
             }
@@ -43,11 +53,15 @@
       "required": [
         "name",
         "value"
-      ]
+      ],
+      "gioConfig": {
+        "uiType": "gio-headers-array"
+      }
     },
-    "body" : {
+    "body": {
       "title": "Request body (support EL)",
-      "type" : "string",
+      "type": "string",
+      "format": "gio-code-editor",
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {
@@ -64,7 +78,7 @@
       "title": "Authentication condition",
       "description": "The condition which will be verified to validate that the authentication is successful (support EL).",
       "default": "{#authResponse.status == 200}",
-      "type" : "string",
+      "type": "string",
       "x-schema-form": {
         "expression-language": true
       }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

![image](https://github.com/gravitee-io/gravitee-resource-auth-provider-http/assets/4974420/910eaea7-6f53-4a2b-9375-1c86611c10a2)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-http/1.4.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-auth-provider-http-1.4.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
