### PR TITLE
feat: upgrade to Vertx 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@5.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["config:base", "schedule:earlyMondays"],
+    "prConcurrentLimit": 3,
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "rangeStrategy": "replace"
+        }
+    ]
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.log.custom.declaration = org.slf4j.Logger io.gravitee.node.logging.NodeLoggerFactory.getLogger(TYPE)

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
     <name>Gravitee.io APIM - Resource - Auth Provider - HTTP</name>
 
     <properties>
-        <gravitee-bom.version>2.1</gravitee-bom.version>
+        <gravitee-bom.version>9.0.0-alpha.5</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-node-api.version>1.20.1</gravitee-node-api.version>
+        <gravitee-gateway-api.version>5.1.1</gravitee-gateway-api.version>
+        <gravitee-node-api.version>8.0.3</gravitee-node-api.version>
         <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -41,10 +41,6 @@
         <gravitee-node-api.version>8.0.3</gravitee-node-api.version>
         <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
 
-        <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
-        <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
     </properties>
@@ -89,6 +85,13 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-logging</artifactId>
             <version>${gravitee-node-api.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -144,23 +147,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/assembly/resource-assembly.xml
+++ b/src/assembly/resource-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/authprovider/http/AuthenticationResponse.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/AuthenticationResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,10 @@ public class AuthenticationResponse {
         this.content = content;
         this.headers = new HttpHeaders(response.headers().size());
 
-        response.headers().names().forEach(headerName -> this.headers.put(headerName, response.headers().getAll(headerName)));
+        response
+            .headers()
+            .names()
+            .forEach(headerName -> this.headers.put(headerName, response.headers().getAll(headerName)));
     }
 
     public int getStatus() {

--- a/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
@@ -128,7 +128,7 @@ public class HttpAuthenticationProviderResource
             context.getTemplateEngine().getTemplateContext().setVariable("username", username);
             context.getTemplateEngine().getTemplateContext().setVariable("password", password);
 
-            httpClientRequest.setTimeout(30000L);
+            httpClientRequest.idleTimeout(30000L);
             httpClientRequest.headers().add(HttpHeaders.USER_AGENT, userAgent);
             httpClientRequest.headers().add("X-Gravitee-Request-Id", UUID.toString(UUID.random()));
 

--- a/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/HttpAuthenticationProviderResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,8 +36,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -47,11 +46,10 @@ import org.springframework.core.env.Environment;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class HttpAuthenticationProviderResource
     extends AuthenticationProviderResource<HttpAuthenticationProviderResourceConfiguration>
     implements ApplicationContextAware {
-
-    private final Logger logger = LoggerFactory.getLogger(HttpAuthenticationProviderResource.class);
 
     private static final String HTTPS_SCHEME = "https";
 
@@ -103,7 +101,7 @@ public class HttpAuthenticationProviderResource
                 try {
                     httpClient.close();
                 } catch (IllegalStateException ise) {
-                    logger.warn(ise.getMessage());
+                    log.warn(ise.getMessage());
                 }
             });
     }
@@ -112,7 +110,7 @@ public class HttpAuthenticationProviderResource
     public void authenticate(String username, String password, ExecutionContext context, Handler<Authentication> handler) {
         HttpClient httpClient = httpClients.computeIfAbsent(Vertx.currentContext(), __ -> vertx.createHttpClient(httpClientOptions));
 
-        logger.debug("Authenticate user requesting {}", configuration().getUrl());
+        log.debug("Authenticate user requesting {}", configuration().getUrl());
 
         RequestOptions requestOpts = new RequestOptions()
             .setAbsoluteURI(configuration().getUrl())
@@ -194,7 +192,7 @@ public class HttpAuthenticationProviderResource
                     handler.handle(null);
                 }
             } catch (ExpressionEvaluationException e) {
-                logger.warn(e.getMessage());
+                log.warn(e.getMessage());
                 handler.handle(null);
             }
         });
@@ -235,12 +233,12 @@ public class HttpAuthenticationProviderResource
         if (errors.length() == 0) {
             return proxyOptions;
         } else {
-            logger.warn(
+            log.warn(
                 "HTTP authentication provider requires a system proxy to be defined to call [{}] but some configurations are missing or not well defined: {}",
                 configuration().getUrl(),
                 errors
             );
-            logger.warn("Ignoring system proxy");
+            log.warn("Ignoring system proxy");
             return null;
         }
     }

--- a/src/main/java/io/gravitee/resource/authprovider/http/configuration/HttpAuthenticationProviderResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/configuration/HttpAuthenticationProviderResourceConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/resource/authprovider/http/configuration/HttpHeader.java
+++ b/src/main/java/io/gravitee/resource/authprovider/http/configuration/HttpHeader.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,92 +1,75 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "method": {
-      "title": "HTTP Method",
-      "description": "HTTP method to invoke the endpoint.",
-      "type": "string",
-      "default": "POST",
-      "enum": [
-        "GET",
-        "POST",
-        "PUT",
-        "DELETE",
-        "PATCH",
-        "HEAD",
-        "CONNECT",
-        "OPTIONS",
-        "TRACE"
-      ]
-    },
-    "useSystemProxy": {
-      "title": "Use system proxy",
-      "description": "Use the system proxy configured by your administrator.",
-      "type": "boolean"
-    },
-    "url": {
-      "title": "URL",
-      "description": "Server url",
-      "type": "string"
-    },
-    "headers": {
-      "type": "array",
-      "title": "Request Headers",
-      "description": "Header value support EL",
-      "items": {
-        "type": "object",
-        "title": "Header",
-        "properties": {
-          "name": {
-            "title": "Name",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "method": {
+            "title": "HTTP Method",
+            "description": "HTTP method to invoke the endpoint.",
+            "type": "string",
+            "default": "POST",
+            "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "CONNECT", "OPTIONS", "TRACE"]
+        },
+        "useSystemProxy": {
+            "title": "Use system proxy",
+            "description": "Use the system proxy configured by your administrator.",
+            "type": "boolean"
+        },
+        "url": {
+            "title": "URL",
+            "description": "Server url",
             "type": "string"
-          },
-          "value": {
-            "title": "Value (support EL)",
+        },
+        "headers": {
+            "type": "array",
+            "title": "Request Headers",
+            "description": "Header value support EL",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Value (support EL)",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                }
+            },
+            "required": ["name", "value"],
+            "gioConfig": {
+                "uiType": "gio-headers-array"
+            }
+        },
+        "body": {
+            "title": "Request body (support EL)",
+            "type": "string",
+            "format": "gio-code-editor",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Put request body here",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true
+                },
+                "expression-language": true
+            }
+        },
+        "condition": {
+            "title": "Authentication condition",
+            "description": "The condition which will be verified to validate that the authentication is successful (support EL).",
+            "default": "{#authResponse.status == 200}",
             "type": "string",
             "x-schema-form": {
-              "expression-language": true
+                "expression-language": true
             }
-          }
         }
-      },
-      "required": [
-        "name",
-        "value"
-      ],
-      "gioConfig": {
-        "uiType": "gio-headers-array"
-      }
     },
-    "body": {
-      "title": "Request body (support EL)",
-      "type": "string",
-      "format": "gio-code-editor",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Put request body here",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true
-        },
-        "expression-language": true
-      }
-    },
-    "condition": {
-      "title": "Authentication condition",
-      "description": "The condition which will be verified to validate that the authentication is successful (support EL).",
-      "default": "{#authResponse.status == 200}",
-      "type": "string",
-      "x-schema-form": {
-        "expression-language": true
-      }
-    }
-  },
-  "required": [
-    "method",
-    "url",
-    "condition"
-  ]
+    "required": ["method", "url", "condition"]
 }


### PR DESCRIPTION
BREAKING CHANGE: upgrade to vertx 5.x

**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

upgrade to Vertx 5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-feat-upgrade-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-auth-provider-http/2.0.0-feat-upgrade-vertx5-SNAPSHOT/gravitee-resource-auth-provider-http-2.0.0-feat-upgrade-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
